### PR TITLE
Updated package.json so it works in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint src --fix",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text npm run test",
     "analyze": "webpack --profile --json > stats.json",
-    "manual-test": "webpack-dev-server  --webpack-config webpack.test.config.js  './src/manual_test.js' --hot --inline --output-filename 'test.js'",
+    "manual-test": "webpack-dev-server  --webpack-config webpack.test.config.js ./src/manual_test.js --hot --inline --output-filename 'test.js'",
     "semantic-release": "semantic-release",
     "test:e2e": "webpack src/manual_test.js  --output-filename test.js --config webpack.config.js && mocha-webpack \"src/e2e-test.js\" --timeout 80000 --webpack-config webpack.test.config.js  --require babel-polyfill"
   },


### PR DESCRIPTION
removed the quotes around ./src/manual_test.js 
changed
 "manual-test": "webpack-dev-server  --webpack-config webpack.test.config.js './src/manual_test.js' --hot --inline --output-filename 'test.js'",
  
to
 "manual-test": "webpack-dev-server  --webpack-config webpack.test.config.js ./src/manual_test.js --hot --inline --output-filename 'test.js'",